### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/idvoretskyi/ollama-k8s/security/code-scanning/1](https://github.com/idvoretskyi/ollama-k8s/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly define the permissions required for the workflow. Based on the tasks performed in the workflow, the minimal required permission is `contents: read`, as the workflow only needs to read repository files (e.g., Kubernetes manifests and shell scripts) for validation purposes. No write permissions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
